### PR TITLE
fix: fallback to curl when wget is not available

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ categories = [
 
 [build-dependencies]
 anyhow = "1.0.80"
+which = "6.0.3"

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,7 @@
 use std::{env, fs, path::Path, process::Command};
 
 use anyhow::anyhow;
+use which::which;
 
 fn join(root: &str, next: &str) -> anyhow::Result<String> {
     Ok(Path::new(root)
@@ -10,7 +11,7 @@ fn join(root: &str, next: &str) -> anyhow::Result<String> {
         .to_string())
 }
 
-fn is_exsit(dir: &str) -> bool {
+fn exists(dir: &str) -> bool {
     fs::metadata(dir).is_ok()
 }
 
@@ -55,20 +56,31 @@ fn library_name(complete: bool) -> String {
     }
 }
 
+fn get_download_executable() -> anyhow::Result<&'static str> {
+    if which("wget").is_ok() {
+        Ok("wget")
+    } else if which("curl").is_ok() {
+        Ok("curl --remote-name")
+    } else {
+        Err(anyhow!("Neither wget nor curl found on the system to download precompiled binaries"))
+    }
+}
+
 fn main() -> anyhow::Result<()> {
     println!("cargo:cargo:rerun-if-env-changed=./src");
-    
+
     let repository = env::var("CARGO_PKG_REPOSITORY").unwrap();
     let version = env::var("CARGO_PKG_VERSION").unwrap();
     let output = env::var("OUT_DIR").unwrap();
 
-    if !is_exsit(&join(&output, &library_name(true))?) {
+    if !exists(&join(&output, &library_name(true))?) {
         let url = format!("{}/releases/download/v{}/{}", repository, version, library_name(true));
         if cfg!(target_os = "windows") {
             exec(&format!("Invoke-WebRequest -Uri {} -OutFile {}", url, library_name(true)),
                  &output)
         } else {
-            exec(&format!("wget {}", url), &output)
+            let download_executable = get_download_executable()?;
+            exec(&format!("{} {}", download_executable, url), &output)
         }.expect("There is no precompiled binary library file in git \
                 releases, please try to compile it yourself according to the \
                 README, see https://github.com/colourful-rtc/libyuv-rs");


### PR DESCRIPTION
Macs don't have `wget`. `curl --remote-name` = `curl -O`, and I prefer to use the [long-hand form](https://www.seandeaton.com/stop-using-single-letter-command-line-options/).